### PR TITLE
feat(chat): add real-time message read notification

### DIFF
--- a/src/ui/common/molecules/AddFriend.tsx
+++ b/src/ui/common/molecules/AddFriend.tsx
@@ -55,7 +55,6 @@ const AddFriend: React.FC<RightSideBarProps> = ({ setTestId }) => {
     viewUsers();
   }, []);
 
-  // Client-side socket event handling
   useEffect(() => {
     if (socket) {
       console.log('Socket connected from AddFriend:', socket.connected);


### PR DESCRIPTION
- Implemented real-time notifications for when a user marks messages as read.
- Added `messagesRead` socket event to notify clients when their messages have been read.
- Updated `useEffect` to handle the `messagesRead` event and reset the unread message count for the appropriate user.
- Ensured that the `messagesRead` event is emitted only to the intended recipient, preventing infinite request loops.